### PR TITLE
Fix segfault over Ubuntu (maybe for other distro too)

### DIFF
--- a/plymouth/jelly-in-a-truck.script
+++ b/plymouth/jelly-in-a-truck.script
@@ -38,6 +38,8 @@ fun draw_next_frame() {
 }
 
 
-load_sprites(boot, "jiat_", 100);
-Plymouth.SetRefreshFunction(draw_next_frame);
+if (Plymouth.GetMode() == "boot") {
+    load_sprites("jiat_", 100);
+    Plymouth.SetRefreshFunction(draw_next_frame);
+}
 


### PR DESCRIPTION
the function in origin script only has two args, while it is called with three args. 
I removed the undeclared arg `boot` , added a condition to display the splash if called when booting. 
I don't know if it is expected behavior, at least after this commit it works on my machine without giving sigsegv to journalctl.